### PR TITLE
Change event to fire on keyup instead of change

### DIFF
--- a/js/LFCalc.js
+++ b/js/LFCalc.js
@@ -16,7 +16,7 @@ gform.addAction( 'gform_post_calculation_events', function( mergeTagArr, formula
         if ( mergeTagArr[2] != null ) {
             var columnNo = mergeTagArr[2].substr( 1 ),
                 columnSelector = '.gfield_list_' + fieldId + '_cell' + columnNo + ' :input';
-            jQuery( fieldSelector ).on( 'change', columnSelector, function () {
+            jQuery( fieldSelector ).on( 'keyup', columnSelector, function () {
                 calcObj.bindCalcEvent( fieldId, formulaField, formId, 0 );
             });
         }


### PR DESCRIPTION
Hey,

Great plugin, exactly what I needed.

I'm just wondering if you wanted to change the event that fires the calculation process to 'keyup' instead of 'change' (which is essentially 'blur' in this case). This would bring it in line with how the standard Gravity Forms calculations function.

Tested on Mac Safari, FireFox, Edge, IE, Chrome - doesn't appear to have an adverse affects. 
