### PR TITLE
 Add check to avoid error when calling get_input_type() $field is not a field

### DIFF
--- a/RWListFieldCalculations.php
+++ b/RWListFieldCalculations.php
@@ -64,9 +64,9 @@ if ( class_exists( 'GFForms' ) ) {
                         $lfield   = RGFormsModel::get_field( $form, $field_id );
                         
                         // check that we have a field
-						if ( ! $lfield ) {
-							continue;
-						}
+                        if ( ! $lfield ) {
+                            continue;
+                        }
 
                         // check the field type as we only want the rest of the function to run if the field type is list
                         if ( $lfield->get_input_type() != 'list' ) {
@@ -114,9 +114,9 @@ if ( class_exists( 'GFForms' ) ) {
                     $field    = RGFormsModel::get_field( $form, $field_id );
                     
                     // check that we have a field
-					if ( ! $field ) {
-						continue;
-					}
+                    if ( ! $field ) {
+                        continue;
+                    }
 
                     // check the field type as we only want the rest of the function to run if the field type is list
                     if ( $field->get_input_type() != 'list' ) {

--- a/RWListFieldCalculations.php
+++ b/RWListFieldCalculations.php
@@ -62,6 +62,11 @@ if ( class_exists( 'GFForms' ) ) {
                         // get the $field object for the provided id
                         $field_id = $match[1];
                         $lfield   = RGFormsModel::get_field( $form, $field_id );
+                        
+                        // check that we have a field
+						if ( ! $lfield ) {
+							continue;
+						}
 
                         // check the field type as we only want the rest of the function to run if the field type is list
                         if ( $lfield->get_input_type() != 'list' ) {
@@ -107,6 +112,11 @@ if ( class_exists( 'GFForms' ) ) {
                     // get the $field object for the provided id
                     $field_id = $match[1];
                     $field    = RGFormsModel::get_field( $form, $field_id );
+                    
+                    // check that we have a field
+					if ( ! $field ) {
+						continue;
+					}
 
                     // check the field type as we only want the rest of the function to run if the field type is list
                     if ( $field->get_input_type() != 'list' ) {


### PR DESCRIPTION
I came across an issue where my form stopped loading on the front end - the whole form didn't render - no <form> etc just an empty page template.
I narrowed it down to having a formula in a number field that references a field that I had deleted.
I then noticed the error only happened when this plugin was active.

To reproduce: create a form, create a calculation formula and then delete one of the fields that are part of the formula. Preview or run the form on the front end and the form fails to load.
The following error message appears in debug mode.
Fatal error: Uncaught Error: Call to a member function get_input_type() on null 

Changes are to check that $field is not null before attempting to get type.

You may have a better way to approach the issue.
