### PR TITLE
PHP error if field has no values

### DIFF
--- a/RWListFieldCalculations.php
+++ b/RWListFieldCalculations.php
@@ -124,7 +124,7 @@ if ( class_exists( 'GFForms' ) ) {
                     }
 
                     // get the list fields values from the $lead
-                    $list_values = unserialize( $lead[ $field_id ] );
+                    $list_values = empty( $lead[ $field_id ] ) ? array() : unserialize( $lead[ $field_id ] );
                     $count       = 0;
 
                     // if column number found sum column values otherwise count number of rows


### PR DESCRIPTION
If you create a calculation based on a list field but the list field has no values entered, when the form is submitted you see a PHP error message from this addon.

`Warning: Invalid argument supplied for foreach() in /wp-content/plugins/RWListFieldCalculations-master/RWListFieldCalculations.php on line 143`

It doesn't break the calculations, everything seems to work as normal but I propose a change to avoid the message.

The change is to set $list_values as an empty array if there are no values for the field.

Not sure if this is the best approach so feel free to implement as you see fit.