### PR TITLE
use gform_loaded hook to load plugin

### DIFF
--- a/RWListFieldCalculations.php
+++ b/RWListFieldCalculations.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms List Field Calculations Add-On
 Plugin URI:
 Description: A simple add-on to enable the use of List fields in calculations.
-Version: 0.6
+Version: 0.7
 Author: Richard Wawrzyniak
 Author URI:
 
@@ -27,12 +27,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 //------------------------------------------
 
-if ( class_exists( 'GFForms' ) ) {
+add_action( 'gform_loaded', function(){
     GFForms::include_addon_framework();
 
     class RWListFieldCalculations extends GFAddOn {
 
-        protected $_version = '0.6';
+        protected $_version = '0.7';
         protected $_min_gravityforms_version = '2.3';
         protected $_slug = 'RWListFieldCalculations';
         protected $_path = 'RWListFieldCalculations/RWListFieldCalculations.php';
@@ -47,7 +47,7 @@ if ( class_exists( 'GFForms' ) ) {
             add_filter( 'gform_custom_merge_tags', array( $this, 'list_field_calculations_merge_tags' ), 10, 4 );
         }
 
-        function has_list_field_merge_tag( $form ) {
+        public static function has_list_field_merge_tag( $form ) {
             foreach ( $form['fields'] as $field ) {
                 if ( ! $field->has_calculation() ) {
                     continue;
@@ -62,7 +62,7 @@ if ( class_exists( 'GFForms' ) ) {
                         // get the $field object for the provided id
                         $field_id = $match[1];
                         $lfield   = GFAPI::get_field( $form, $field_id );
-                        
+
                         // check that we have a field
                         if ( ! $lfield ) {
                             continue;
@@ -84,7 +84,7 @@ if ( class_exists( 'GFForms' ) ) {
             return false;
         }
 
-        function list_field_calculations_script( $form ) {
+        public function list_field_calculations_script( $form ) {
 
             if ( self::has_list_field_merge_tag( $form ) ) {
                 wp_enqueue_script( 'LFCalc', $this->get_base_url() . '/js/LFCalc.js', array(
@@ -95,7 +95,7 @@ if ( class_exists( 'GFForms' ) ) {
 
         }
 
-        function list_field_calculations( $formula, $field, $form, $lead ) {
+        public function list_field_calculations( $formula, $field, $form, $lead ) {
 
             // {List:1.3} - {Label:ID.Column} - sum column values
             // {List:1} - {Label:ID} - count rows
@@ -112,7 +112,7 @@ if ( class_exists( 'GFForms' ) ) {
                     // get the $field object for the provided id
                     $field_id = $match[1];
                     $field    = GFAPI::get_field( $form, $field_id );
-                    
+
                     // check that we have a field
                     if ( ! $field ) {
                         continue;
@@ -163,7 +163,7 @@ if ( class_exists( 'GFForms' ) ) {
             return $formula;
         }
 
-        function list_field_calculations_merge_tags( $merge_tags, $form_id, $fields, $element_id ) {
+        public function list_field_calculations_merge_tags( $merge_tags, $form_id, $fields, $element_id ) {
 
             // check the type of merge tag dropdown
             if ( $element_id != 'field_calculation_formula' ) {
@@ -206,4 +206,4 @@ if ( class_exists( 'GFForms' ) ) {
     }
 
     new RWListFieldCalculations();
-}
+}, 10, 0 );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
 -------------------------------------------------------------------------------------------------------------------
+Version 0.7
+    - Use gravity form hook gform_loaded for loading the addon
+
+-------------------------------------------------------------------------------------------------------------------
 Version 0.6
     - Updated min Gravity Forms version to 2.3
     - Fixed the gform_merge_tag_value_pre_calculation callback for Gravity Forms 2.4.


### PR DESCRIPTION
If gravity forms is disabled, then enabled again the addon will **not** load in its current state because `class_exists` is ran before GF code is loaded. This PR solves that problem by using the recommended hook from Gravity Forms.

